### PR TITLE
Alternate Strategy to avoid IE engine issue

### DIFF
--- a/Citrix-Workspace/tools/ChocolateyInstall.ps1
+++ b/Citrix-Workspace/tools/ChocolateyInstall.ps1
@@ -1,6 +1,6 @@
 ## Template VirtualEngine.Build ChocolateyInstall.ps1 file for EXE/MSI installations
 
-$releaseUri = 'https://www.citrix.com/downloads/workspace-app/legacy-workspace-app-for-windows/workspace-app-for-windows-1903.html'
+$releaseUri = "https://www.citrix.com/downloads/workspace-app/legacy-workspace-app-for-windows/workspace-app-for-windows-1903.html"
 $downloadLink = 'https:{0}' -f ((Invoke-WebRequest -Uri $releaseUri -UseBasicParsing).Links | Where-Object { $_.href -eq '#ctx-dl-eula' } | Select-Object -ExpandProperty 'rel')
 
 $installChocolateyPackageParams = @{

--- a/Citrix-Workspace/tools/ChocolateyInstall.ps1
+++ b/Citrix-Workspace/tools/ChocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ## Template VirtualEngine.Build ChocolateyInstall.ps1 file for EXE/MSI installations
 
 $releaseUri = 'https://www.citrix.com/downloads/workspace-app/legacy-workspace-app-for-windows/workspace-app-for-windows-1903.html'
-$downloadLink = 'https:{0}' -f ((Invoke-WebRequest -Uri $releaseUri).Links | Where-Object { $_.href -eq '#ctx-dl-eula' } | Select-Object -ExpandProperty 'rel')
+$downloadLink = 'https:{0}' -f ((Invoke-WebRequest -Uri $releaseUri -UseBasicParsing).Links | Where-Object { $_.href -eq '#ctx-dl-eula' } | Select-Object -ExpandProperty 'rel')
 
 $installChocolateyPackageParams = @{
     PackageName    = "Citrix-Workspace";

--- a/Citrix-Workspace/tools/ChocolateyInstall.ps1
+++ b/Citrix-Workspace/tools/ChocolateyInstall.ps1
@@ -1,7 +1,30 @@
 ## Template VirtualEngine.Build ChocolateyInstall.ps1 file for EXE/MSI installations
 
 $releaseUri = "https://www.citrix.com/downloads/workspace-app/legacy-workspace-app-for-windows/workspace-app-for-windows-1903.html"
-$downloadLink = 'https:{0}' -f ((Invoke-WebRequest -Uri $releaseUri -UseBasicParsing).Links | Where-Object { $_.href -eq '#ctx-dl-eula' } | Select-Object -ExpandProperty 'rel')
+$checksum = "086DBE728BFBA427D1DF28C3A7ADEB072CD3878758084A547879759EE36064B5"
+
+$READYSTATE_READY = 4
+
+Write-Host "Starting IE"
+$ie = New-Object -comobject InternetExplorer.Application
+
+Write-Host "Navigating"
+$ie.Navigate2($releaseUri) 
+$ie.Visible = $false
+
+while($ie.ReadyState -ne $READYSTATE_READY) {
+    Write-Host "Not ready yet, Waiting"
+    start-sleep -Seconds 2
+}
+
+Write-Host "Done Processing Web Site"
+$link = $ie.Document.getElementsByTagName("a") | Where-Object { $_.href -like "*.html#ctx-dl-eula" } | select -First 1 
+
+$downloadUri = "https:" + $link.rel
+
+Write-Host "Link is $downloadUri"
+
+$ie.quit()
 
 $installChocolateyPackageParams = @{
     PackageName    = "Citrix-Workspace";
@@ -9,7 +32,7 @@ $installChocolateyPackageParams = @{
     SilentArgs     = "/noreboot /silent";
     Url            = "$downloadUri";
     ValidExitCodes = @(0,3010);
-    Checksum       = "086DBE728BFBA427D1DF28C3A7ADEB072CD3878758084A547879759EE36064B5";
+    Checksum       = "$checksum";
     ChecksumType   = "sha256";
 }
 Install-ChocolateyPackage @installChocolateyPackageParams;


### PR DESCRIPTION
Resolves #4.

Trying this quickly from mobile so I haven't been able to test it yet.

But per [this SO post](https://stackoverflow.com/q/38005341), I believe adding `-UseBasicParsing` should do the trick.

From [the docs](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-4.0)

> Uses the response object for HTML content without Document Object Model (DOM) parsing.
> This parameter is required when Internet Explorer is not installed on the computers, such as on a Server Core installation of a Windows Server operating system.

As of powershell 5 I believe it's all done this way regardless so this is backwards compatible too. 👍

## Options

❌ Use Invoke-WebRequest (error message about IE engine)
❌ Use `-UseBasicParsing` (won't allow for URLs generated via Javascript)
✅  Use the COM object for `InternetExplorer.Application` ([Example](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/automatic/wps-office-free/update_helper.ps1))
❔ Take a pre-requisite on another cmd line util that parses html? 