### PR TITLE
replace deprecated .NET dependency

### DIFF
--- a/Citrix-Workspace-LTSR/Citrix-Workspace-LTSR.nuspec
+++ b/Citrix-Workspace-LTSR/Citrix-Workspace-LTSR.nuspec
@@ -15,7 +15,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <tags>Citrix Receiver Workspace WorkspaceApp Admin LTSR</tags>
     <dependencies>
-      <dependency id="dotnet4.6.2" />
+      <dependency id="netfx-4.6.2" />
     </dependencies>
     <packageSourceUrl>https://github.com/iainbrighton/Chocolatey-Packages/tree/master/Citrix-Workspace-LTSR</packageSourceUrl>
   </metadata>

--- a/Citrix-Workspace/Citrix-Workspace.nuspec
+++ b/Citrix-Workspace/Citrix-Workspace.nuspec
@@ -15,7 +15,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <tags>Citrix Receiver Workspace WorkspaceApp Admin</tags>
     <dependencies>
-      <dependency id="dotnet4.6.2" />
+      <dependency id="netfx-4.6.2" />
     </dependencies>
     <packageSourceUrl>https://github.com/iainbrighton/Chocolatey-Packages/tree/master/Citrix-Workspace</packageSourceUrl>
   </metadata>


### PR DESCRIPTION
The previously used package [dotnet4.6.2](https://community.chocolatey.org/packages/dotnet4.6.2) is marked deprecated and was replace by [netfx-4.6.2](https://community.chocolatey.org/packages/netfx-4.6.2).