### PR TITLE
Updated Citrix Workspace App LTSR to 2203 (new LTSR)

### DIFF
--- a/Citrix-Workspace-LTSR/Citrix-Workspace-LTSR.nuspec
+++ b/Citrix-Workspace-LTSR/Citrix-Workspace-LTSR.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>citrix-workspace-ltsr</id>
     <title>Citrix Workspace LTSR</title>
-    <version>19.12.6000.9</version>
+    <version>22.3.0.38</version>
     <authors>Citrix Systems Inc.</authors>
     <owners>Iain Brighton</owners>
     <summary>Citrix Workspace LTSR</summary>
@@ -15,7 +15,8 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <tags>Citrix Receiver Workspace WorkspaceApp Admin LTSR</tags>
     <dependencies>
-      <dependency id="dotnet4.6.2" />
+      <dependency id="netfx-4.8" />
+      <dependency id="vcredist140" />
     </dependencies>
     <packageSourceUrl>https://github.com/iainbrighton/Chocolatey-Packages/tree/master/Citrix-Workspace-LTSR</packageSourceUrl>
   </metadata>

--- a/Citrix-Workspace-LTSR/tools/ChocolateyInstall.ps1
+++ b/Citrix-Workspace-LTSR/tools/ChocolateyInstall.ps1
@@ -6,9 +6,9 @@ $installChocolateyPackageParams = @{
     PackageName    = "Citrix-Workspace-LTSR";
     FileType       = "EXE";
     SilentArgs     = "/noreboot /silent /AutoUpdateCheck=disabled";
-    Url            = "https://downloadplugins.citrix.com/ReceiverUpdates/Prod/Receiver/Win/CitrixWorkspaceApp19.12.6000.9.exe";
+    Url            = "https://downloadplugins.citrix.com/ReceiverUpdates/Prod/Receiver/Win/CitrixWorkspaceApp22.3.0.38.exe";
     ValidExitCodes = @(0,3010,40008);
-    Checksum       = "c5abca7edb8076410151914e36f583f75bfca9d8f2b7798f84aa6ac4457f9b4f";
+    Checksum       = "bc61b5a29f05fb68f11c116c96d38ff76e6aaaa2612740b8bdf37620abfc757b";
     ChecksumType   = "sha256";
 }
 Install-ChocolateyPackage @installChocolateyPackageParams;

--- a/Citrix-Workspace-LTSR/tools/ChocolateyUninstall.ps1
+++ b/Citrix-Workspace-LTSR/tools/ChocolateyUninstall.ps1
@@ -2,6 +2,6 @@
 
 <#! PRE-UNINSTALL-TASKS !#>
 
-Uninstall-ChocolateyPackage -PackageName 'Citrix-Workspace-LTSR' -FileType 'EXE' -SilentArgs '/silent /uninstall /cleanup' -File "$((${env:ProgramFiles(x86)}, $env:ProgramFiles -ne $null)[0])\Citrix\Citrix Workspace 1912\TrolleyExpress.exe" -ValidExitCodes @(0,3010);
+Uninstall-ChocolateyPackage -PackageName 'Citrix-Workspace-LTSR' -FileType 'EXE' -SilentArgs '/silent /uninstall /cleanup' -File "$((${env:ProgramFiles(x86)}, $env:ProgramFiles -ne $null)[0])\Citrix\Citrix Workspace 2203\TrolleyExpress.exe" -ValidExitCodes @(0,3010);
 
 <#! POST-UNINSTALL-TASKS !#>


### PR DESCRIPTION
Updated Citrix Workspace App LTSR to 2203 (new LTSR branch). It would be possible to continue with the 1912 LTSR branch, but then I suggest a dedicated Chocolatey package for that one and keep this as "latest"