### PR TITLE
Introduce check for already installed conflicting package of Workspace App

### DIFF
--- a/Citrix-Workspace-LTSR/tools/ChocolateyInstall.ps1
+++ b/Citrix-Workspace-LTSR/tools/ChocolateyInstall.ps1
@@ -1,5 +1,27 @@
 ﻿## Template VirtualEngine.Build ChocolateyInstall.ps1 file for EXE/MSI installations
+function Test-ChocolateyPackageInstalled {
+    Param (
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Package
+    )
 
+    Process {
+        if (Test-Path -Path $env:ChocolateyInstall) {
+            $packageInstalled = Test-Path -Path $env:ChocolateyInstall\lib\$Package
+        }
+        else {
+            throw "Can't find a chocolatey install directory..."
+        }
+
+        return $packageInstalled
+    }
+}
+
+If (Test-ChocolateyPackageInstalled -Package "citrix-workspace")
+{
+    throw "Citrix Workspace CR already installed. Aborting Citrix Workspace LTSR install"
+}
 <#! PRE-INSTALL-TASKS !#>
 
 $installChocolateyPackageParams = @{

--- a/Citrix-Workspace/tools/ChocolateyInstall.ps1
+++ b/Citrix-Workspace/tools/ChocolateyInstall.ps1
@@ -1,5 +1,27 @@
 ﻿## Template VirtualEngine.Build ChocolateyInstall.ps1 file for EXE/MSI installations
+function Test-ChocolateyPackageInstalled {
+    Param (
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Package
+    )
 
+    Process {
+        if (Test-Path -Path $env:ChocolateyInstall) {
+            $packageInstalled = Test-Path -Path $env:ChocolateyInstall\lib\$Package
+        }
+        else {
+            throw "Can't find a chocolatey install directory..."
+        }
+
+        return $packageInstalled
+    }
+}
+
+If (Test-ChocolateyPackageInstalled -Package "citrix-workspace-ltsr")
+{
+    throw "Citrix Workspace LTSR already installed. Aborting Citrix Workspace CR install"
+}
 <#! PRE-INSTALL-TASKS !#>
 
 $installChocolateyPackageParams = @{


### PR DESCRIPTION
This is implemented to prevent issues when attempting to install CR version when already having LTSR installed and vice versa. This does not prevent conflict for installs performed without Chocolatey. This could be implemented aswell, but is more difficult.